### PR TITLE
Clauncher and Clawitzer do not get Shell Smash

### DIFF
--- a/learnsets-g6/learnsets-g6-A-to-C.txt
+++ b/learnsets-g6/learnsets-g6-A-to-C.txt
@@ -3481,7 +3481,6 @@ L? - Flail
 L? - Muddy Water
 L? - Water Sport
 L? - Smack Down
-L? - Shell Smash
 L30 - Crabhammer
 L34 - Water Pulse
 TM - Swords Dance
@@ -3526,7 +3525,6 @@ L? - Crabhammer
 L? - Flail
 L? - Water Sport
 L? - Water Pulse
-L? - Shell Smash
 L? - Heal Pulse
 L42 - Smack Down
 L47 - Aqua Jet


### PR DESCRIPTION
http://www.smogon.com/forums/threads/clawitzer.3490081/#post-4895386 and following posts
It was originally posted on Serebii that they got it at 42 and 47 respectively, which has since been changed to the correct move: Aqua Jet
